### PR TITLE
Allow `options.logger` in andLogResults

### DIFF
--- a/src/fibrous_loggable_futures.coffee
+++ b/src/fibrous_loggable_futures.coffee
@@ -1,6 +1,6 @@
 _ = require 'underscore'
 
-module.exports = (fibrous, logger) ->
+module.exports = (fibrous, defaultLogger) ->
   Future = fibrous.Future
 
   # various signatures that andLogResults handles:
@@ -14,6 +14,7 @@ module.exports = (fibrous, logger) ->
     if _(contextMsg).isObject()
       [contextMsg, options] = [contextObj.msg, contextMsg]
     options ?= {}
+    logger = options.logger ? defaultLogger
     throw new Error('You must supply a contextMsg to andLogResults') if !contextMsg
     @resolve (err, result) ->
       if err?

--- a/test/fibrous_loggable_futures.test.coffee
+++ b/test/fibrous_loggable_futures.test.coffee
@@ -41,6 +41,14 @@ describe 'fibrous-loggable-futures', ->
         expect(-> fibrous.sync.waitForLoggedFutures()).to.throw('boom')
         expect(@logger.error).to.have.been.calledWith({err}, '"some message"', 'error from Future#andLogResults')
 
+      describe 'with a custom logger', ->
+        it 'logs the error with the custom logger', ->
+          customLogger = error: @sinon.spy()
+          obj.future.asyncF().andLogResults({contextKey: 'contextValue'}, 'some message', {logger: customLogger})
+          expect(-> fibrous.sync.waitForLoggedFutures()).to.throw('boom')
+          expect(@logger.error).not.to.have.been.called
+          expect(customLogger.error).to.have.been.calledWith({err, contextKey: 'contextValue'}, '"some message"', 'error from Future#andLogResults')
+
   describe '.waitForLoggedFutures', ->
     describe 'when not capturing logged futures', ->
       it 'throws', ->


### PR DESCRIPTION
This is to help get some essential metadata into our email futures.